### PR TITLE
Fix `httpClient` should not throw if user is disconnected

### DIFF
--- a/packages/ra-auth-auth0/src/httpClient.ts
+++ b/packages/ra-auth-auth0/src/httpClient.ts
@@ -9,7 +9,12 @@ export const httpClient = (auth0Client: any) => async (
     url: any,
     options: fetchUtils.Options | undefined
 ) => {
-    const token = await auth0Client.getTokenSilently();
+    let token: string | null = null;
+    try {
+        token = await auth0Client.getTokenSilently();
+    } catch (error) {
+        // Nothing to do, we just won't set the Authorization header
+    }
     const requestHeaders = getAuth0Headers(token, options);
     return fetchUtils.fetchJson(url, {
         ...options,


### PR DESCRIPTION
**Problem**

If the token cannot be acquired from the cache (e.g. because it is no longer valid or because the user is disconnected), calling `auth0Client.getTokenSilently()` in `httpClient` will throw an `Error` (e.g. a `Login required` error).

The problem is that this will block the actual request from firing, and it will not necessarily trigger a new login attempt since `authProvider.checkError()` won't throw in that case.

**Solution**

Catch any error  thrown while calling `auth0Client.getTokenSilently()` in `httpClient`, and rely on the fact that the API will then be called without the `Authorization` header, which should return a 401 or 403 status code (if the endpoint is protected) which should activate `authProvider.checkError()`.