### PR TITLE
Fix logout should wait for client logout to complete before redirecting

### DIFF
--- a/packages/ra-auth-auth0/src/authProvider.ts
+++ b/packages/ra-auth-auth0/src/authProvider.ts
@@ -78,13 +78,12 @@ export const Auth0AuthProvider = (
     },
     // called when the user clicks on the logout button
     async logout() {
-        return client
-            .logout({
-                logoutParams: {
-                    returnTo: logoutRedirectUri || window.location.origin,
-                },
-            })
-            .then(() => logoutRedirectUri || '/');
+        await client.logout({
+            logoutParams: {
+                returnTo: logoutRedirectUri || window.location.origin,
+            },
+        });
+        return false;
     },
     // called when the API returns an error
     async checkError({ status }) {


### PR DESCRIPTION
**Problem**

With the current implementation, the redirection at logout is managed by react-admin, and does not wait for the auth0 js client logout to complete, which can lead to race conditions causing the logout not to reach completion.

**Solution**

Return `false` to disable the react-admin redirect, and rely only the the auth0 js client to perform the redirect.