### PR TITLE
Remove react, react-dom from peerDependencies

### DIFF
--- a/packages/ra-auth-auth0/package.json
+++ b/packages/ra-auth-auth0/package.json
@@ -16,9 +16,7 @@
     "sideEffects": false,
     "peerDependencies": {
         "@auth0/auth0-spa-js": "^2.0.0",
-        "react": "^18.0.0 || ^19.0.0",
-        "react-admin": "^5.1.1",
-        "react-dom": "^18.0.0 || ^19.0.0"
+        "react-admin": "^5.1.1"
     },
     "scripts": {
         "build": "yarn run build-cjs && yarn run build-esm",


### PR DESCRIPTION
This package does not actually interact directly with either `react` nor `react-dom`. It never imports anything from them or does anything to them. Simply declaring the peerDependency on `react-admin` should be enough.

Removing these peerDependencies helps to install this package into a monorepo where some apps are still on React 17 and others are on 18. Otherwise we have to install using `npm install --force`.